### PR TITLE
requirements.txtの依存関係指定を緩めた

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,55 +1,57 @@
 # Nexus Ark Distribution Requirements
-# Last Updated: 2025-10-18 (RAG support added)
+# Last Updated: 2025-10-21 (Version constraints relaxed to major versions)
 
 # --- Core Frameworks ---
-gradio==5.47.0
-gradio_client==1.13.2
-langchain==0.3.27
-langchain-core==0.3.76
-langchain-google-genai==2.1.12
-langgraph==0.6.7
-google-genai==1.38.0
-pillow==11.3.0
+gradio>=5.0.0,<6.0.0
+gradio_client>=1.0.0,<2.0.0
+langchain>=0.3.0,<0.4.0
+langchain-core>=0.3.0,<0.4.0
+langchain-google-genai>=2.0.0,<3.0.0
+langgraph>=0.6.0,<0.7.0
+google-genai>=1.0.0,<2.0.0
+pillow>=11.0.0,<12.0.0
 
 # --- RAG (Knowledge Base) Feature ---
-faiss-cpu==1.12.0
-langchain-faiss==0.1.1
-langchain-community==0.3.29
+faiss-cpu>=1.12.0,<2.0.0
+langchain-faiss>=0.1.0,<0.2.0
+langchain-community>=0.3.0,<0.4.0
 
 # --- UI & Data Handling ---
-pandas==2.3.2
-beautifulsoup4==4.13.5
-lxml==6.0.2
+pandas>=2.0.0,<3.0.0
+beautifulsoup4>=4.12.0,<5.0.0
+lxml>=6.0.0,<7.0.0
 
 # --- Subprocess & Notifications ---
-psutil==7.1.0
-plyer==2.1.0
-schedule==1.2.2
-requests==2.32.5
-pywin32==311; sys_platform == 'win32'
+psutil>=7.0.0,<8.0.0
+plyer>=2.0.0,<3.0.0
+schedule>=1.2.0,<2.0.0
+requests>=2.32.0,<3.0.0
+pywin32>=311; sys_platform == 'win32'
 
 # --- File & System Utilities ---
-filetype==1.2.0
-python-dateutil==2.9.0.post0
-pytz==2025.2
-ijson==3.4.0
-concurrent-log-handler==0.9.28
+filetype>=1.2.0,<2.0.0
+python-dateutil>=2.9.0,<3.0.0
+pytz>=2025.1
+ijson>=3.4.0,<4.0.0
+concurrent-log-handler>=0.9.0,<1.0.0
 
-# --- LangChain/LangGraph Dependencies (Verified) ---
-aiohttp==3.12.15
-anyio==4.11.0
-fastapi==0.117.1
-httpx==0.28.1
-numpy==2.3.3
-orjson==3.11.3
-pydantic==2.11.9
-PyYAML==6.0.2
-SQLAlchemy==2.0.43
-tenacity==9.1.2
+# --- LangChain/LangGraph Dependencies ---
+aiohttp>=3.12.0,<4.0.0
+anyio>=4.0.0,<5.0.0
+fastapi>=0.117.0,<1.0.0
+httpx>=0.28.0,<1.0.0
+numpy>=2.3.0,<3.0.0
+matplotlib>=3.10.0
+orjson>=3.11.0,<4.0.0
+pydantic>=2.11.0,<3.0.0
+PyYAML>=6.0.0,<7.0.0
+SQLAlchemy>=2.0.0,<3.0.0
+tenacity>=9.0.0,<10.0.0
 
 # --- Audio dependency ---
-pydub==0.25.1
+pydub>=0.25.0,<1.0.0
 
 # --- Markdown rendering ---
-markdown-it-py~=3.0.0
-mdit-py-plugins~=0.4.0
+markdown-it-py>=3.0.0,<4.0.0
+mdit-py-plugins>=0.4.0,<1.0.0
+


### PR DESCRIPTION
requirements.txtの依存関係指定を緩め、追加でmatplotlibを明示的に指定し、issue #2 に対応